### PR TITLE
feat(prettier-config): add plugin to sort the keys of a package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,11 +34,13 @@
 				"lodash": "^4.17.15",
 				"postcss": "^8.4.12",
 				"postcss-less": "^6.0.0",
+				"prettier-package-json": "^2.6.3",
 				"prettier-plugin-organize-attributes": "~0.0.5",
 				"rxjs": "^6.5.2",
 				"rxjs-tslint": "^0.1.7",
 				"rxjs-tslint-rules": "^4.24.3",
 				"semver": "^6.3.0",
+				"sort-package-json": "^1.55.0",
 				"stylelint": "^14.6.1",
 				"stylelint-config-prettier": "^9.0.3",
 				"stylelint-config-standard": "^25.0.0",
@@ -1652,9 +1654,9 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs2": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.17.8.tgz",
-			"integrity": "sha512-KWN7KTjojEVk+hhT7EtvWtSBTueqnPiCT2xPoDFF+ept2Sx9UKnLY7hGsnrNsdx7jvMUQnHoDS6AHCys7i15LA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.17.9.tgz",
+			"integrity": "sha512-+QThIsnjVY12uURTvmnW33risFZ7ulq6OWw0VJL08UwiYiWVp9PM63s+W1L2ppajYyKAYKb7afcGYSHzA0k04Q==",
 			"dependencies": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.4"
@@ -1664,9 +1666,9 @@
 			}
 		},
 		"node_modules/@babel/runtime-corejs3": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.8.tgz",
-			"integrity": "sha512-ZbYSUvoSF6dXZmMl/CYTMOvzIFnbGfv4W3SEHYgMvNsFTeLaF2gkGAF4K2ddmtSK4Emej+0aYcnSC6N5dPCXUQ==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.9.tgz",
+			"integrity": "sha512-WxYHHUWF2uZ7Hp1K+D1xQgbgkGUfA+5UPOegEXGt2Y5SMog/rYCVaifLZDbw8UkNXozEqqrZTy6bglL7xTaCOw==",
 			"dependencies": {
 				"core-js-pure": "^3.20.2",
 				"regenerator-runtime": "^0.13.4"
@@ -5252,6 +5254,15 @@
 			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
+		"node_modules/@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"dependencies": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
 		"node_modules/@types/graceful-fs": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -5307,8 +5318,7 @@
 		"node_modules/@types/minimatch": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-			"dev": true
+			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
 		},
 		"node_modules/@types/minimist": {
 			"version": "1.2.2",
@@ -5318,13 +5328,17 @@
 		"node_modules/@types/node": {
 			"version": "14.17.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
-			"integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
-			"dev": true
+			"integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA=="
 		},
 		"node_modules/@types/normalize-package-data": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+		},
+		"node_modules/@types/parse-author": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/parse-author/-/parse-author-2.0.1.tgz",
+			"integrity": "sha512-2RNXvvDY+7ITl/Q3znDpW9DxyAckKgLCXpoiBHN9BeLH1aV7z/W657P2+PK3wVUgGWXtc99ZQy3LkJTGlxLsvA=="
 		},
 		"node_modules/@types/parse-json": {
 			"version": "4.0.0",
@@ -5637,18 +5651,26 @@
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
+		"node_modules/@typescript-eslint/utils/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/@typescript-eslint/utils/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
@@ -6131,6 +6153,14 @@
 			},
 			"engines": {
 				"node": ">= 4.5.0"
+			}
+		},
+		"node_modules/author-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
+			"integrity": "sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA=",
+			"engines": {
+				"node": ">=0.8"
 			}
 		},
 		"node_modules/aws-sign2": {
@@ -7231,9 +7261,12 @@
 			}
 		},
 		"node_modules/commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==",
+			"engines": {
+				"node": ">= 6"
+			}
 		},
 		"node_modules/comment-parser": {
 			"version": "0.7.6",
@@ -8295,7 +8328,6 @@
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
 			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-			"dev": true,
 			"engines": {
 				"node": ">=8"
 			}
@@ -9234,18 +9266,26 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/eslint-plugin-functional/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/eslint-plugin-functional/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/eslint-plugin-html": {
@@ -10854,6 +10894,14 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"node_modules/git-hooks-list": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
+			"integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ==",
+			"funding": {
+				"url": "https://github.com/fisker/git-hooks-list?sponsor=1"
+			}
+		},
 		"node_modules/git-raw-commits": {
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.10.tgz",
@@ -11312,11 +11360,14 @@
 			"dev": true
 		},
 		"node_modules/html-tags": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-			"integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg==",
 			"engines": {
 				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/htmlparser2": {
@@ -14172,7 +14223,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
 			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
@@ -14184,7 +14234,6 @@
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
 			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-			"dev": true,
 			"engines": {
 				"node": ">= 10.0.0"
 			}
@@ -16618,6 +16667,17 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
+		"node_modules/parse-author": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
+			"integrity": "sha1-00YL8d3Q367tQtp1QkLmX7aEqB8=",
+			"dependencies": {
+				"author-regex": "^1.0.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -16921,6 +16981,46 @@
 			},
 			"engines": {
 				"node": ">=6.0.0"
+			}
+		},
+		"node_modules/prettier-package-json": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/prettier-package-json/-/prettier-package-json-2.6.3.tgz",
+			"integrity": "sha512-0zFMAyiSHImUb7VWJQFiORFaFJ46gtLZ05sHRkehSZ6aO9mO8pxSStkTnpIT7rIioQMJhnaF9LKcqJpmhHf6JQ==",
+			"dependencies": {
+				"@types/parse-author": "^2.0.0",
+				"commander": "^4.0.1",
+				"cosmiconfig": "^7.0.0",
+				"fs-extra": "^10.0.0",
+				"glob": "^7.1.6",
+				"minimatch": "^3.0.4",
+				"parse-author": "^2.0.0",
+				"sort-object-keys": "^1.1.3",
+				"sort-order": "^1.0.1"
+			},
+			"bin": {
+				"prettier-package-json": "bin/prettier-package-json"
+			}
+		},
+		"node_modules/prettier-package-json/node_modules/fs-extra": {
+			"version": "10.0.1",
+			"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+			"integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/prettier-package-json/node_modules/universalify": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+			"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/prettier-plugin-organize-attributes": {
@@ -18006,18 +18106,26 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/rxjs-tslint-rules/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/rxjs-tslint-rules/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
 			}
 		},
 		"node_modules/rxjs-tslint-rules/node_modules/tslib": {
@@ -18659,6 +18767,66 @@
 			},
 			"engines": {
 				"node": ">=4"
+			}
+		},
+		"node_modules/sort-object-keys": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+			"integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg=="
+		},
+		"node_modules/sort-order": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sort-order/-/sort-order-1.0.1.tgz",
+			"integrity": "sha1-2CK4zbkOpqnfloxL1FmHz1SBmeY="
+		},
+		"node_modules/sort-package-json": {
+			"version": "1.55.0",
+			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.55.0.tgz",
+			"integrity": "sha512-xhKvRD8WGbALjXQkVuk4/93Z/2NIO+5IzKamdMjN5kn3L+N+M9YWQssmM6GXlQr9v1F7PGWsOJEo1gvXOhM7Mg==",
+			"dependencies": {
+				"detect-indent": "^6.0.0",
+				"detect-newline": "3.1.0",
+				"git-hooks-list": "1.0.3",
+				"globby": "10.0.0",
+				"is-plain-obj": "2.1.0",
+				"sort-object-keys": "^1.1.3"
+			},
+			"bin": {
+				"sort-package-json": "cli.js"
+			}
+		},
+		"node_modules/sort-package-json/node_modules/detect-indent": {
+			"version": "6.1.0",
+			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+			"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA==",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/sort-package-json/node_modules/globby": {
+			"version": "10.0.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
+			"integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
+			"dependencies": {
+				"@types/glob": "^7.1.1",
+				"array-union": "^2.1.0",
+				"dir-glob": "^3.0.1",
+				"fast-glob": "^3.0.3",
+				"glob": "^7.1.3",
+				"ignore": "^5.1.1",
+				"merge2": "^1.2.3",
+				"slash": "^3.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/sort-package-json/node_modules/is-plain-obj": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+			"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+			"engines": {
+				"node": ">=8"
 			}
 		},
 		"node_modules/source-map": {
@@ -19415,17 +19583,25 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/semver": {
-			"version": "7.3.5",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-			"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+			"version": "7.3.6",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+			"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 			"dependencies": {
-				"lru-cache": "^6.0.0"
+				"lru-cache": "^7.4.0"
 			},
 			"bin": {
 				"semver": "bin/semver.js"
 			},
 			"engines": {
-				"node": ">=10"
+				"node": "^10.0.0 || ^12.0.0 || ^14.0.0 || >=16.0.0"
+			}
+		},
+		"node_modules/stylelint/node_modules/semver/node_modules/lru-cache": {
+			"version": "7.7.3",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+			"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw==",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/stylelint/node_modules/type-fest": {
@@ -19962,6 +20138,11 @@
 			"dependencies": {
 				"@babel/runtime-corejs2": "^7.1.5"
 			}
+		},
+		"node_modules/tslint/node_modules/commander": {
+			"version": "2.20.3",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
 		},
 		"node_modules/tslint/node_modules/semver": {
 			"version": "5.7.1",
@@ -20951,7 +21132,22 @@
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
-				"eslint-plugin-import": "^2.25.4"
+				"@babel/eslint-parser": "^7.14.7",
+				"@babel/eslint-plugin": "^7.14.5",
+				"@typescript-eslint/eslint-plugin": "^5.4.0",
+				"@typescript-eslint/parser": "^5.4.0",
+				"eslint": "^7.5.0",
+				"eslint-config-airbnb-base": "^14.2.0",
+				"eslint-config-prettier": "^6.11.0",
+				"eslint-import-resolver-typescript": "^2.5.0",
+				"eslint-import-resolver-webpack": "^0.12.2",
+				"eslint-plugin-eslint-comments": "^3.2.0",
+				"eslint-plugin-import": "^2.25.4",
+				"eslint-plugin-jest": "^23.18.0",
+				"eslint-plugin-prettier": "^3.1.4",
+				"eslint-plugin-promise": "^4.2.1",
+				"eslint-plugin-sort-class-members": "^1.7.0",
+				"prettier": "2.6.2"
 			}
 		},
 		"packages/eslint-plugin": {
@@ -22047,18 +22243,18 @@
 			}
 		},
 		"@babel/runtime-corejs2": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.17.8.tgz",
-			"integrity": "sha512-KWN7KTjojEVk+hhT7EtvWtSBTueqnPiCT2xPoDFF+ept2Sx9UKnLY7hGsnrNsdx7jvMUQnHoDS6AHCys7i15LA==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs2/-/runtime-corejs2-7.17.9.tgz",
+			"integrity": "sha512-+QThIsnjVY12uURTvmnW33risFZ7ulq6OWw0VJL08UwiYiWVp9PM63s+W1L2ppajYyKAYKb7afcGYSHzA0k04Q==",
 			"requires": {
 				"core-js": "^2.6.5",
 				"regenerator-runtime": "^0.13.4"
 			}
 		},
 		"@babel/runtime-corejs3": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.8.tgz",
-			"integrity": "sha512-ZbYSUvoSF6dXZmMl/CYTMOvzIFnbGfv4W3SEHYgMvNsFTeLaF2gkGAF4K2ddmtSK4Emej+0aYcnSC6N5dPCXUQ==",
+			"version": "7.17.9",
+			"resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.17.9.tgz",
+			"integrity": "sha512-WxYHHUWF2uZ7Hp1K+D1xQgbgkGUfA+5UPOegEXGt2Y5SMog/rYCVaifLZDbw8UkNXozEqqrZTy6bglL7xTaCOw==",
 			"requires": {
 				"core-js-pure": "^3.20.2",
 				"regenerator-runtime": "^0.13.4"
@@ -24796,7 +24992,22 @@
 		"@tinkoff/eslint-config": {
 			"version": "file:packages/eslint-config",
 			"requires": {
-				"eslint-plugin-import": "^2.25.4"
+				"@babel/eslint-parser": "^7.14.7",
+				"@babel/eslint-plugin": "^7.14.5",
+				"@typescript-eslint/eslint-plugin": "^5.4.0",
+				"@typescript-eslint/parser": "^5.4.0",
+				"eslint": "^7.5.0",
+				"eslint-config-airbnb-base": "^14.2.0",
+				"eslint-config-prettier": "^6.11.0",
+				"eslint-import-resolver-typescript": "^2.5.0",
+				"eslint-import-resolver-webpack": "^0.12.2",
+				"eslint-plugin-eslint-comments": "^3.2.0",
+				"eslint-plugin-import": "^2.25.4",
+				"eslint-plugin-jest": "^23.18.0",
+				"eslint-plugin-prettier": "^3.1.4",
+				"eslint-plugin-promise": "^4.2.1",
+				"eslint-plugin-sort-class-members": "^1.7.0",
+				"prettier": "2.6.2"
 			}
 		},
 		"@tinkoff/eslint-plugin": {
@@ -24870,6 +25081,15 @@
 			"integrity": "sha512-C6N5s2ZFtuZRj54k2/zyRhNDjJwwcViAM3Nbm8zjBpbqAdZ00mr0CFxvSKeO8Y/e03WVFLpQMdHYVfUd6SB+Hw==",
 			"dev": true
 		},
+		"@types/glob": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.2.0.tgz",
+			"integrity": "sha512-ZUxbzKl0IfJILTS6t7ip5fQQM/J3TJYubDm3nMbgubNNYS62eXeUpoLUC8/7fJNiFYHTrGPQn7hspDUzIHX3UA==",
+			"requires": {
+				"@types/minimatch": "*",
+				"@types/node": "*"
+			}
+		},
 		"@types/graceful-fs": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.5.tgz",
@@ -24925,8 +25145,7 @@
 		"@types/minimatch": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
-			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==",
-			"dev": true
+			"integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
 		},
 		"@types/minimist": {
 			"version": "1.2.2",
@@ -24936,13 +25155,17 @@
 		"@types/node": {
 			"version": "14.17.5",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.17.5.tgz",
-			"integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA==",
-			"dev": true
+			"integrity": "sha512-bjqH2cX/O33jXT/UmReo2pM7DIJREPMnarixbQ57DOOzzFaI6D2+IcwaJQaJpv0M1E9TIhPCYVxrkcityLjlqA=="
 		},
 		"@types/normalize-package-data": {
 			"version": "2.4.1",
 			"resolved": "https://registry.npmjs.org/@types/normalize-package-data/-/normalize-package-data-2.4.1.tgz",
 			"integrity": "sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw=="
+		},
+		"@types/parse-author": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@types/parse-author/-/parse-author-2.0.1.tgz",
+			"integrity": "sha512-2RNXvvDY+7ITl/Q3znDpW9DxyAckKgLCXpoiBHN9BeLH1aV7z/W657P2+PK3wVUgGWXtc99ZQy3LkJTGlxLsvA=="
 		},
 		"@types/parse-json": {
 			"version": "4.0.0",
@@ -25126,12 +25349,17 @@
 					"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.3.0.tgz",
 					"integrity": "sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA=="
 				},
+				"lru-cache": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.4.0"
 					}
 				}
 			}
@@ -25506,6 +25734,11 @@
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
+		},
+		"author-regex": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/author-regex/-/author-regex-1.0.0.tgz",
+			"integrity": "sha1-0IiFvmubv5Q5/gh8dihyRfCoFFA="
 		},
 		"aws-sign2": {
 			"version": "0.7.0",
@@ -26392,9 +26625,9 @@
 			}
 		},
 		"commander": {
-			"version": "2.20.3",
-			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-4.1.1.tgz",
+			"integrity": "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="
 		},
 		"comment-parser": {
 			"version": "0.7.6",
@@ -27254,8 +27487,7 @@
 		"detect-newline": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
-			"dev": true
+			"integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
 		},
 		"dezalgo": {
 			"version": "1.0.3",
@@ -28058,12 +28290,17 @@
 					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
 				},
+				"lru-cache": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.4.0"
 					}
 				}
 			}
@@ -29162,6 +29399,11 @@
 				"assert-plus": "^1.0.0"
 			}
 		},
+		"git-hooks-list": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/git-hooks-list/-/git-hooks-list-1.0.3.tgz",
+			"integrity": "sha512-Y7wLWcrLUXwk2noSka166byGCvhMtDRpgHdzCno1UQv/n/Hegp++a2xBWJL1lJarnKD3SWaljD+0z1ztqxuKyQ=="
+		},
 		"git-raw-commits": {
 			"version": "2.0.10",
 			"resolved": "https://registry.npmjs.org/git-raw-commits/-/git-raw-commits-2.0.10.tgz",
@@ -29521,9 +29763,9 @@
 			"dev": true
 		},
 		"html-tags": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.1.0.tgz",
-			"integrity": "sha512-1qYz89hW3lFDEazhjW0yVAV87lw8lVkrJocr72XmBkMKsoSVJCQx3W8BXsC7hO2qAt8BoVjYjtAcZ9perqGnNg=="
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/html-tags/-/html-tags-3.2.0.tgz",
+			"integrity": "sha512-vy7ClnArOZwCnqZgvv+ddgHgJiAFXe3Ge9ML5/mBctVJoUoYPCdxVucOywjDARn6CVoh3dRSFdPHy2sX80L0Wg=="
 		},
 		"htmlparser2": {
 			"version": "7.2.0",
@@ -31643,7 +31885,6 @@
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
 			"integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6",
 				"universalify": "^2.0.0"
@@ -31652,8 +31893,7 @@
 				"universalify": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
-					"dev": true
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
 				}
 			}
 		},
@@ -33558,6 +33798,14 @@
 				"safe-buffer": "^5.1.1"
 			}
 		},
+		"parse-author": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/parse-author/-/parse-author-2.0.0.tgz",
+			"integrity": "sha1-00YL8d3Q367tQtp1QkLmX7aEqB8=",
+			"requires": {
+				"author-regex": "^1.0.0"
+			}
+		},
 		"parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
@@ -33771,6 +34019,39 @@
 			"dev": true,
 			"requires": {
 				"fast-diff": "^1.1.2"
+			}
+		},
+		"prettier-package-json": {
+			"version": "2.6.3",
+			"resolved": "https://registry.npmjs.org/prettier-package-json/-/prettier-package-json-2.6.3.tgz",
+			"integrity": "sha512-0zFMAyiSHImUb7VWJQFiORFaFJ46gtLZ05sHRkehSZ6aO9mO8pxSStkTnpIT7rIioQMJhnaF9LKcqJpmhHf6JQ==",
+			"requires": {
+				"@types/parse-author": "^2.0.0",
+				"commander": "^4.0.1",
+				"cosmiconfig": "^7.0.0",
+				"fs-extra": "^10.0.0",
+				"glob": "^7.1.6",
+				"minimatch": "^3.0.4",
+				"parse-author": "^2.0.0",
+				"sort-object-keys": "^1.1.3",
+				"sort-order": "^1.0.1"
+			},
+			"dependencies": {
+				"fs-extra": {
+					"version": "10.0.1",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.0.1.tgz",
+					"integrity": "sha512-NbdoVMZso2Lsrn/QwLXOy6rm0ufY2zEOKCDzJR/0kBsb0E6qed0P3iYK+Ath3BfvXEeu4JhEtXLgILx5psUfag==",
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^6.0.1",
+						"universalify": "^2.0.0"
+					}
+				},
+				"universalify": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+					"integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+				}
 			}
 		},
 		"prettier-plugin-organize-attributes": {
@@ -34615,12 +34896,17 @@
 					"resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
 					"integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ=="
 				},
+				"lru-cache": {
+					"version": "7.7.3",
+					"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+					"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.4.0"
 					}
 				},
 				"tslib": {
@@ -35125,6 +35411,56 @@
 			"dev": true,
 			"requires": {
 				"is-plain-obj": "^1.0.0"
+			}
+		},
+		"sort-object-keys": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/sort-object-keys/-/sort-object-keys-1.1.3.tgz",
+			"integrity": "sha512-855pvK+VkU7PaKYPc+Jjnmt4EzejQHyhhF33q31qG8x7maDzkeFhAAThdCYay11CISO+qAMwjOBP+fPZe0IPyg=="
+		},
+		"sort-order": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/sort-order/-/sort-order-1.0.1.tgz",
+			"integrity": "sha1-2CK4zbkOpqnfloxL1FmHz1SBmeY="
+		},
+		"sort-package-json": {
+			"version": "1.55.0",
+			"resolved": "https://registry.npmjs.org/sort-package-json/-/sort-package-json-1.55.0.tgz",
+			"integrity": "sha512-xhKvRD8WGbALjXQkVuk4/93Z/2NIO+5IzKamdMjN5kn3L+N+M9YWQssmM6GXlQr9v1F7PGWsOJEo1gvXOhM7Mg==",
+			"requires": {
+				"detect-indent": "^6.0.0",
+				"detect-newline": "3.1.0",
+				"git-hooks-list": "1.0.3",
+				"globby": "10.0.0",
+				"is-plain-obj": "2.1.0",
+				"sort-object-keys": "^1.1.3"
+			},
+			"dependencies": {
+				"detect-indent": {
+					"version": "6.1.0",
+					"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
+					"integrity": "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="
+				},
+				"globby": {
+					"version": "10.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-10.0.0.tgz",
+					"integrity": "sha512-3LifW9M4joGZasyYPz2A1U74zbC/45fvpXUvO/9KbSa+VV0aGZarWkfdgKyR9sExNP0t0x0ss/UMJpNpcaTspw==",
+					"requires": {
+						"@types/glob": "^7.1.1",
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.0.3",
+						"glob": "^7.1.3",
+						"ignore": "^5.1.1",
+						"merge2": "^1.2.3",
+						"slash": "^3.0.0"
+					}
+				},
+				"is-plain-obj": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+					"integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA=="
+				}
 			}
 		},
 		"source-map": {
@@ -35681,11 +36017,18 @@
 					}
 				},
 				"semver": {
-					"version": "7.3.5",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
-					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"version": "7.3.6",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.6.tgz",
+					"integrity": "sha512-HZWqcgwLsjaX1HBD31msI/rXktuIhS+lWvdE4kN9z+8IVT4Itc7vqU2WvYsyD6/sjYCt4dEKH/m1M3dwI9CC5w==",
 					"requires": {
-						"lru-cache": "^6.0.0"
+						"lru-cache": "^7.4.0"
+					},
+					"dependencies": {
+						"lru-cache": {
+							"version": "7.7.3",
+							"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.7.3.tgz",
+							"integrity": "sha512-WY9wjJNQt9+PZilnLbuFKM+SwDull9+6IAguOrarOMoOHTcJ9GnXSO11+Gw6c7xtDkBkthR57OZMtZKYr+1CEw=="
+						}
 					}
 				},
 				"type-fest": {
@@ -36096,6 +36439,11 @@
 				"tsutils": "^2.29.0"
 			},
 			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				},
 				"semver": {
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",

--- a/packages/prettier-config/angular.js
+++ b/packages/prettier-config/angular.js
@@ -43,7 +43,16 @@ module.exports = {
     },
     {
       files: ['package.json', 'ng-package.json'],
-      options: { parser: 'json-stringify' },
+      options: {
+        parser: 'json-stringify',
+        plugins: [
+          require('path').resolve(
+            __dirname,
+            'plugins',
+            'prettier-plugin-sort-package'
+          ),
+        ],
+      },
     },
     {
       files: ['*.less'],

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -23,7 +23,9 @@
   "dependencies": {
     "@prettier/plugin-xml": "~2.0.1",
     "@types/prettier": "^2.4.4",
+    "prettier-package-json": "^2.6.3",
+    "prettier-plugin-organize-attributes": "~0.0.5",
     "prettier": "2.6.2",
-    "prettier-plugin-organize-attributes": "~0.0.5"
+    "sort-package-json": "^1.55.0"
   }
 }

--- a/packages/prettier-config/plugins/prettier-plugin-sort-package.js
+++ b/packages/prettier-config/plugins/prettier-plugin-sort-package.js
@@ -1,0 +1,31 @@
+const sortPackageJson = require('sort-package-json');
+const { parsers } = require('prettier/parser-babel');
+
+const parser = parsers['json-stringify'];
+
+exports.parsers = {
+  'json-stringify': {
+    ...parser,
+    preprocess(text, options) {
+      const processed = parser.preprocess
+        ? parser.preprocess(text, options)
+        : text;
+
+      const isPackageJson =
+        options.filepath &&
+        /package\.json$|ng-package\.json$/.test(options.filepath);
+
+      if (isPackageJson) {
+        const json = JSON.parse(processed);
+
+        const scripts = JSON.parse(JSON.stringify(json?.scripts ?? {}));
+        const sorted = sortPackageJson(json);
+        sorted.scripts = scripts; // ignore sorting scripts
+
+        return JSON.stringify(sorted);
+      }
+
+      return processed;
+    },
+  },
+};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

often there is disagreement that the newline that the developer added is out of order

![image](https://user-images.githubusercontent.com/12021443/161992561-09f75589-995a-4c1c-a162-a54c34766ca8.png)

## What is the new behavior?

Add a [Prettier](https://github.com/prettier/prettier) plugin to sort the keys of a package.json file using [sort-package-json](https://github.com/keithamus/sort-package-json).

