### PR TITLE
feat(eslint-config-angular): add decorator position package

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 12.x, 14.x, 16.x]
+        node-version: [14.x, 16.x, 18.x]
 
     steps:
     - uses: actions/checkout@v2

--- a/packages/eslint-config-angular/README.md
+++ b/packages/eslint-config-angular/README.md
@@ -36,6 +36,7 @@ You can also include `optional` configurations, however, you are responsible for
     '@tinkoff/eslint-config-angular/file-progress',
     '@tinkoff/eslint-config-angular/line-statements',
     '@tinkoff/eslint-config-angular/member-ordering',
+    '@tinkoff/eslint-config-angular/decorator-position',
   ],
 }
 ```

--- a/packages/eslint-config-angular/decorator-position/index.js
+++ b/packages/eslint-config-angular/decorator-position/index.js
@@ -1,0 +1,19 @@
+module.exports = {
+  overrides: [
+    {
+      files: ['*.ts'],
+      parser: '@typescript-eslint/parser',
+      plugins: ['@typescript-eslint', 'decorator-position'],
+      rules: {
+        'decorator-position/decorator-position': [
+          'error',
+          {
+            printWidth: 120,
+            properties: 'above',
+            methods: 'above',
+          },
+        ],
+      },
+    },
+  ],
+};

--- a/packages/eslint-config-angular/package.json
+++ b/packages/eslint-config-angular/package.json
@@ -15,6 +15,7 @@
     "member-ordering",
     "promise",
     "file-progress",
+    "decorator-position",
     "recommended",
     "rxjs",
     "index.js",
@@ -35,7 +36,8 @@
     "eslint-plugin-html": "^6.2.0",
     "eslint-plugin-rxjs": "^5.0.2",
     "eslint-plugin-rxjs-angular": "^2.0.0",
-    "eslint-plugin-simple-import-sort": "^7.0.0"
+    "eslint-plugin-simple-import-sort": "^7.0.0",
+    "eslint-plugin-decorator-position": "^5.0.1"
   },
   "peerDependencies": {
     "@tinkoff/eslint-config": "^1.31.1",

--- a/packages/eslint-config-angular/test/decorator-position/__fixtures__/decorator-position-happy.fixture.ts
+++ b/packages/eslint-config-angular/test/decorator-position/__fixtures__/decorator-position-happy.fixture.ts
@@ -1,0 +1,15 @@
+function Output() {
+  return function (target: any, propertyKey: string) {};
+}
+
+function enumerable() {
+  return function (target: any, propertyKey: string) {};
+}
+
+class A {
+  @Output()
+  name: any;
+
+  @enumerable()
+  foo() {}
+}

--- a/packages/eslint-config-angular/test/decorator-position/__fixtures__/decorator-position-unhappy.fixture.ts
+++ b/packages/eslint-config-angular/test/decorator-position/__fixtures__/decorator-position-unhappy.fixture.ts
@@ -1,0 +1,13 @@
+function Input() {
+  return function (target: any, propertyKey: string) {};
+}
+
+function pure() {
+  return function (target: any, propertyKey: string) {};
+}
+
+class B {
+  @Input() name: any;
+
+  @pure() foo() {}
+}

--- a/packages/eslint-config-angular/test/decorator-position/__snapshots__/decorator-position-happy.test.js.snap
+++ b/packages/eslint-config-angular/test/decorator-position/__snapshots__/decorator-position-happy.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`decorator-position / happy path happy 1`] = `""`;

--- a/packages/eslint-config-angular/test/decorator-position/__snapshots__/decorator-position-unhappy.test.js.snap
+++ b/packages/eslint-config-angular/test/decorator-position/__snapshots__/decorator-position-unhappy.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`decorator-position / unhappy path unhappy 1`] = `
+"error: Expected @Input to be on the line above (decorator-position/decorator-position) at packages/eslint-config-angular/test/decorator-position/__fixtures__/decorator-position-unhappy.fixture.ts:10:3:
+   8 | 
+   9 | class B {
+> 10 |   @Input() name: any;
+     |   ^
+  11 | 
+  12 |   @pure() foo() {}
+  13 | }
+
+
+error: Expected @pure to be on the line above (decorator-position/decorator-position) at packages/eslint-config-angular/test/decorator-position/__fixtures__/decorator-position-unhappy.fixture.ts:12:3:
+  10 |   @Input() name: any;
+  11 | 
+> 12 |   @pure() foo() {}
+     |   ^
+  13 | }
+  14 | 
+
+
+2 errors found.
+2 errors potentially fixable with the \`--fix\` option."
+`;

--- a/packages/eslint-config-angular/test/decorator-position/decorator-position-happy.test.js
+++ b/packages/eslint-config-angular/test/decorator-position/decorator-position-happy.test.js
@@ -1,0 +1,25 @@
+import ESlint from 'eslint';
+import path from 'path';
+
+describe('decorator-position / happy path', () => {
+  const cli = new ESlint.CLIEngine({
+    cwd: path.join(__dirname, '..'),
+    useEslintrc: false,
+    baseConfig: {
+      extends: ['../decorator-position'],
+    },
+  });
+
+  it('happy', () => {
+    const codeframe = cli.getFormatter('codeframe');
+
+    const report = cli.executeOnFiles([
+      path.join(
+        __dirname,
+        './__fixtures__/decorator-position-happy.fixture.ts'
+      ),
+    ]);
+
+    expect(codeframe(report.results)).toMatchSnapshot();
+  });
+});

--- a/packages/eslint-config-angular/test/decorator-position/decorator-position-unhappy.test.js
+++ b/packages/eslint-config-angular/test/decorator-position/decorator-position-unhappy.test.js
@@ -1,0 +1,25 @@
+import ESlint from 'eslint';
+import path from 'path';
+
+describe('decorator-position / unhappy path', () => {
+  const cli = new ESlint.CLIEngine({
+    cwd: path.join(__dirname, '..'),
+    useEslintrc: false,
+    baseConfig: {
+      extends: ['../decorator-position'],
+    },
+  });
+
+  it('unhappy', () => {
+    const codeframe = cli.getFormatter('codeframe');
+
+    const report = cli.executeOnFiles([
+      path.join(
+        __dirname,
+        './__fixtures__/decorator-position-unhappy.fixture.ts'
+      ),
+    ]);
+
+    expect(codeframe(report.results)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [x] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

There are no rules that enforce consistent decorator positions.

## What is the new behavior?

Package `decorator-position` is added.
10.x & 12.x node versions are removed from the CI. 18.x is added.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
