### PR TITLE
feat(eslint-config-angular): allow ignoring by void

### DIFF
--- a/packages/eslint-config-angular/promise/index.js
+++ b/packages/eslint-config-angular/promise/index.js
@@ -22,6 +22,8 @@ module.exports = {
           'error',
           { ignoreVoid: true, ignoreIIFE: true },
         ],
+        // for compat with @typescript-eslint/no-floating-promises ignoreVoid
+        'no-void': ['error', { allowAsStatement: true }],
       },
     },
   ],

--- a/packages/eslint-config-angular/promise/index.js
+++ b/packages/eslint-config-angular/promise/index.js
@@ -22,7 +22,6 @@ module.exports = {
           'error',
           { ignoreVoid: true, ignoreIIFE: true },
         ],
-        // for compat with @typescript-eslint/no-floating-promises ignoreVoid
         'no-void': ['error', { allowAsStatement: true }],
       },
     },

--- a/packages/eslint-config-angular/test/promise/__fixtures__/promise-happy.fixture.ts
+++ b/packages/eslint-config-angular/test/promise/__fixtures__/promise-happy.fixture.ts
@@ -1,0 +1,7 @@
+const happyBar = new Promise(() => {});
+void happyBar;
+
+function happyBaz() {
+  return 0;
+}
+void happyBaz();

--- a/packages/eslint-config-angular/test/promise/__fixtures__/promise-unhappy.fixture.ts
+++ b/packages/eslint-config-angular/test/promise/__fixtures__/promise-unhappy.fixture.ts
@@ -1,0 +1,8 @@
+const unhappyBar = new Promise(() => {});
+unhappyBar;
+const unhappyFoo = void unhappyBar;
+
+function unhappyBaz() {
+  return void 0;
+}
+unhappyBaz();

--- a/packages/eslint-config-angular/test/promise/__snapshots__/promise-happy.test.js.snap
+++ b/packages/eslint-config-angular/test/promise/__snapshots__/promise-happy.test.js.snap
@@ -1,0 +1,3 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`promise / happy path happy 1`] = `""`;

--- a/packages/eslint-config-angular/test/promise/__snapshots__/promise-unhappy.test.js.snap
+++ b/packages/eslint-config-angular/test/promise/__snapshots__/promise-unhappy.test.js.snap
@@ -26,7 +26,7 @@ error: Expected 'undefined' and instead saw 'void' (no-void) at packages/eslint-
 > 6 |   return void 0;
     |          ^
   7 | }
-  8 | unhappyBaz()
+  8 | unhappyBaz();
   9 | 
 
 

--- a/packages/eslint-config-angular/test/promise/__snapshots__/promise-unhappy.test.js.snap
+++ b/packages/eslint-config-angular/test/promise/__snapshots__/promise-unhappy.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`promise / unhappy unhappy 1`] = `
+"error: Promises must be awaited, end with a call to .catch, end with a call to .then with a rejection handler or be explicitly marked as ignored with the \`void\` operator (@typescript-eslint/no-floating-promises) at packages/eslint-config-angular/test/promise/__fixtures__/promise-unhappy.fixture.ts:2:1:
+  1 | const unhappyBar = new Promise(() => {});
+> 2 | unhappyBar;
+    | ^
+  3 | const unhappyFoo = void unhappyBar;
+  4 | 
+  5 | function unhappyBaz() {
+
+
+error: Expected 'undefined' and instead saw 'void' (no-void) at packages/eslint-config-angular/test/promise/__fixtures__/promise-unhappy.fixture.ts:3:20:
+  1 | const unhappyBar = new Promise(() => {});
+  2 | unhappyBar;
+> 3 | const unhappyFoo = void unhappyBar;
+    |                    ^
+  4 | 
+  5 | function unhappyBaz() {
+  6 |   return void 0;
+
+
+error: Expected 'undefined' and instead saw 'void' (no-void) at packages/eslint-config-angular/test/promise/__fixtures__/promise-unhappy.fixture.ts:6:10:
+  4 | 
+  5 | function unhappyBaz() {
+> 6 |   return void 0;
+    |          ^
+  7 | }
+  8 | unhappyBaz()
+  9 | 
+
+
+3 errors found."
+`;

--- a/packages/eslint-config-angular/test/promise/promise-happy.test.js
+++ b/packages/eslint-config-angular/test/promise/promise-happy.test.js
@@ -1,0 +1,24 @@
+import ESlint from 'eslint';
+import path from 'path';
+
+describe('promise / happy path', () => {
+  const cli = new ESlint.CLIEngine({
+    cwd: path.join(__dirname, '..'),
+    useEslintrc: false,
+    baseConfig: {
+      extends: ['../promise'],
+      parserOptions: {
+        project: 'tsconfig.json',
+      },
+    },
+  });
+
+  it('happy', () => {
+    const codeframe = cli.getFormatter('codeframe');
+    const report = cli.executeOnFiles([
+      path.join(__dirname, './__fixtures__/promise-happy.fixture.ts'),
+    ]);
+
+    expect(codeframe(report.results)).toMatchSnapshot();
+  });
+});

--- a/packages/eslint-config-angular/test/promise/promise-unhappy.test.js
+++ b/packages/eslint-config-angular/test/promise/promise-unhappy.test.js
@@ -1,0 +1,24 @@
+import ESlint from 'eslint';
+import path from 'path';
+
+describe('promise / unhappy', () => {
+  const cli = new ESlint.CLIEngine({
+    cwd: path.join(__dirname, '..'),
+    useEslintrc: false,
+    baseConfig: {
+      extends: ['../promise'],
+      parserOptions: {
+        project: 'tsconfig.json',
+      },
+    },
+  });
+
+  it('unhappy', () => {
+    const codeframe = cli.getFormatter('codeframe');
+    const report = cli.executeOnFiles([
+      path.join(__dirname, './__fixtures__/promise-unhappy.fixture.ts'),
+    ]);
+
+    expect(codeframe(report.results)).toMatchSnapshot();
+  });
+});


### PR DESCRIPTION
floating promises may be ignored by adding leading "void" keyword

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Trying to ignore floating promises like this:
```
void this.router.navigate(['']);
```
throws error from no-void rule

## What is the new behavior?

no-void rule allow usage as statement

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
