### PR TITLE
feat(stylelint-config): describe angular-less config

### DIFF
--- a/packages/stylelint-config/README.md
+++ b/packages/stylelint-config/README.md
@@ -46,3 +46,11 @@ More information about available at
   "extends": ["@tinkoff/stylelint-config/angular"]
 }
 ```
+
+- **angular-less**
+
+```json
+{
+  "extends": ["@tinkoff/stylelint-config/angular-less"]
+}
+```

--- a/packages/stylelint-config/angular-less.js
+++ b/packages/stylelint-config/angular-less.js
@@ -1,0 +1,11 @@
+const angularConfig = require('./angular');
+const lessConfig = require('./less');
+
+module.exports = {
+  ...angularConfig,
+  customSyntax: lessConfig.customSyntax,
+  rules: {
+    ...angularConfig.rules,
+    ...lessConfig.rules,
+  },
+};


### PR DESCRIPTION
Some projects uses angular with less. Describing of separate angular-less config must hide tricks of combining two configs from package users

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

Angular projects, who uses less, must dive into sources for knowing how to correct combine angular and less configs 

## What is the new behavior?

Angular+less projects can just use separate config

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
