### PR TITLE
fix(prettier-config): fix compat with node 12

### DIFF
--- a/packages/prettier-config/plugins/prettier-plugin-sort-package.js
+++ b/packages/prettier-config/plugins/prettier-plugin-sort-package.js
@@ -17,7 +17,7 @@ exports.parsers = {
 
       if (isPackageJson) {
         const json = JSON.parse(processed);
-        const unsortedScripts = deepClone(json?.scripts ?? {});
+        const unsortedScripts = deepClone((json && json.scripts) || {});
         const sorted = sortPackageJson(json);
 
         /**
@@ -25,7 +25,7 @@ exports.parsers = {
          * the scripts must be unsorted
          */
         // eslint-disable-next-line no-prototype-builtins
-        if (json?.hasOwnProperty('scripts')) {
+        if (json && json.hasOwnProperty('scripts')) {
           sorted.scripts = unsortedScripts;
         }
 


### PR DESCRIPTION
node 12 don't support optional chaining

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

try to run prettier angular config on node 12 throws error `[error] Unexpected token '.'`

## What is the new behavior?

prettifying works normally

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
