### PR TITLE
feat(stylelint-config): add `all` property to properties-order

### DIFF
--- a/packages/stylelint-config/angular.js
+++ b/packages/stylelint-config/angular.js
@@ -4,6 +4,7 @@ module.exports = {
   rules: {
     'order/properties-order': [
       [
+        'all',
         'content',
         'position',
         {

--- a/packages/stylelint-config/stylelint.config.js
+++ b/packages/stylelint-config/stylelint.config.js
@@ -76,6 +76,7 @@ module.exports = {
     ],
     'order/properties-order': [
       [
+        'all',
         'content',
         'position',
         {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows [Conventional Commits](https://www.conventionalcommits.org/en/)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Refactoring
- [ ] Code style update
- [ ] Build or CI related changes
- [ ] Documentation content changes

## What is the current behavior?

[`all`](https://developer.mozilla.org/en-US/docs/Web/CSS/all) property is ignored by properties-order rule. This property allows to reset all CSS-styles but auto-fix mode can lead to unexpected behavior.

For example: https://codesandbox.io/s/all-unset-with-tinkoff-stylelint-6x4jlj

## What is the new behavior?

`all` property has the highest priority in the order

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
